### PR TITLE
fix: update ynab SDK to v4.0.0 and fix renamed API method

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-router-dom": "^6.22.3",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
-    "ynab": "^1.72.0"
+    "ynab": "^4.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.64",

--- a/src/lib/cloner.ts
+++ b/src/lib/cloner.ts
@@ -535,8 +535,8 @@ export async function cloneTransactions(
       }
     } else {
       try {
-        const resp = await client.transactions.createTransactions(destBudgetId, {
-          transactions: batch.map((b) => b.payload as ynab.SaveTransaction),
+        const resp = await client.transactions.createTransaction(destBudgetId, {
+          transactions: batch.map((b) => b.payload as ynab.NewTransaction),
         })
 
         const created = resp.data.transactions ?? []


### PR DESCRIPTION
ynab@^1.72.0 does not exist on npm (latest is 4.0.0), causing the Netlify install to fail with ETARGET. Updates version and adapts the two breaking changes introduced in v4:
- createTransactions() → createTransaction() (method renamed singular)
- SaveTransaction type → NewTransaction type

Response shape (.data.transactions) and all other method signatures are unchanged.

https://claude.ai/code/session_01NHb1u52Kpv9Kcjs1nH4cuy