### PR TITLE
fix: remove unused subMonths import causing TS build error

### DIFF
--- a/src/components/FiltersStep.tsx
+++ b/src/components/FiltersStep.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { format, subDays, subMonths } from 'date-fns'
+import { format, subDays } from 'date-fns'
 import { Loader2, ArrowLeft } from 'lucide-react'
 import type * as ynab from 'ynab'
 import { Button } from '@/components/ui/button'


### PR DESCRIPTION
TypeScript strict mode (noUnusedLocals) treats unused imports as errors. subMonths was imported but never called — date presets use subDays only.

https://claude.ai/code/session_01NHb1u52Kpv9Kcjs1nH4cuy